### PR TITLE
chore: fixed sector drilldown bug

### DIFF
--- a/server/utils/filters.ts
+++ b/server/utils/filters.ts
@@ -37,6 +37,7 @@ export function getFormattedFilters(
     countries: [],
     regions: []
   };
+
   filterKeys.forEach((filterKey: string, index: number) => {
     const addTrailingAND =
       filterKeys.length - 1 !== index &&
@@ -124,9 +125,19 @@ export function getQuery(filters: any, search: string, searchFields: string[]) {
   }
 
   let query = "";
+
+  const locations = {
+    countries: [],
+    regions: []
+  };
+
   if (filterKeys.length > 0) {
     filterKeys.forEach((filterKey: string, index: number) => {
-      if (filterKey === "budget_value") {
+      if (filterKey === "recipient_country_code") {
+        locations.countries = filters[filterKey];
+      } else if (filterKey === "recipient_region_code") {
+        locations.regions = filters[filterKey];
+      } else if (filterKey === "budget_value") {
         query += `${filterKey}:[${filters[filterKey].join(" TO ")}]${
           index === filterKeys.length - 1 ? "" : " AND "
         }`;
@@ -178,6 +189,20 @@ export function getQuery(filters: any, search: string, searchFields: string[]) {
         }`;
       }
     });
+  }
+
+  if (locations.countries.length > 0 || locations.regions.length > 0) {
+    query += `${query.length > 0 ? " AND " : ""}(${
+      locations.countries.length > 0
+        ? `recipient_country_code:(${locations.countries.join(" ")})`
+        : ""
+    }${
+      locations.regions.length > 0
+        ? `${
+            locations.countries.length > 0 ? "OR " : ""
+          }recipient_region_code:(${locations.regions.join(" ")})`
+        : ""
+    })`;
   }
 
   if (search.length > 0 && filterKeys.length > 0) {


### PR DESCRIPTION
Regarding this issue: https://zimmermanzimmerman.atlassian.net/browse/MF-491
Tested all the available filters and only countries/regions was causing this error -  copied over the implementation from `getFormattedFilters` from the same file.

I think why she happend to think that is was on all the filters, is because when you reset the filters and countries/regions have been selected - the recipient_region_code get's stuck in the url. In the app it looks like there aren't any filters selected. Will resolve this issue now and if I can't get it fixed in time will create ticket. 